### PR TITLE
[bugfix]input problem with IME 

### DIFF
--- a/codejar.ts
+++ b/codejar.ts
@@ -73,9 +73,7 @@ export function CodeJar(editor: HTMLElement, highlight: (e: HTMLElement) => void
   })
 
   on("keyup", event => {
-    if(event.isComposing) {
-      return
-    }
+    if(event.isComposing) return
 
     debounceHighlight()
     debounceRecordHistory(event)

--- a/codejar.ts
+++ b/codejar.ts
@@ -73,6 +73,10 @@ export function CodeJar(editor: HTMLElement, highlight: (e: HTMLElement) => void
   })
 
   on("keyup", event => {
+    if(event.isComposing) {
+      return
+    }
+
     debounceHighlight()
     debounceRecordHistory(event)
     if (callback) callback(toString())


### PR DESCRIPTION
It has some problem when input Chinese words by IME, the input area repeats textContent in element. I recode a gif image to describe the problem. 

![](https://user-images.githubusercontent.com/424491/79001532-347fa680-7b81-11ea-8223-75f04dd8c229.gif)

With the pr fixed, it will be ok like following gif

![](https://user-images.githubusercontent.com/424491/79002105-56c5f400-7b82-11ea-8c43-93e595970c57.gif)
