### PR TITLE
Typescript compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules/
 package-lock.json
 *.js
+*.d.ts

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Create element and init:
 ```html
 <div class="editor"></div>
 <script>
-  let jar = new CodeJar(document.querySelector('.editor'), Prism.highlightElement)
+  let jar = CodeJar(document.querySelector('.editor'), Prism.highlightElement)
 </script>
 ```
 
@@ -44,7 +44,7 @@ const highlight = (editor: HTMLElement) => {
   editor.innerHTML = code
 }
 
-let jar = new CodeJar(editor, highlight)
+let jar = CodeJar(editor, highlight)
 ```
 
 Third argument to `CodeJar` is options:
@@ -54,7 +54,7 @@ let options = {
   tab: ' '.repeat(4), // default is \t
 }
 
-let jar = new CodeJar(editor, highlight, options)
+let jar = CodeJar(editor, highlight, options)
 ```
 
 Some styles may be applied to our editor to make it better looking:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Create element and init:
 ```html
 <div class="editor"></div>
 <script>
-  let jar = CodeJar(document.querySelector('.editor'), Prism.highlightElement)
+  let jar = new CodeJar(document.querySelector('.editor'), Prism.highlightElement)
 </script>
 ```
 
@@ -44,7 +44,7 @@ const highlight = (editor: HTMLElement) => {
   editor.innerHTML = code
 }
 
-let jar = CodeJar(editor, highlight)
+let jar = new CodeJar(editor, highlight)
 ```
 
 Third argument to `CodeJar` is options:
@@ -54,7 +54,7 @@ let options = {
   tab: ' '.repeat(4), // default is \t
 }
 
-let jar = CodeJar(editor, highlight, options)
+let jar = new CodeJar(editor, highlight, options)
 ```
 
 Some styles may be applied to our editor to make it better looking:

--- a/codejar.ts
+++ b/codejar.ts
@@ -13,9 +13,7 @@ type Position = {
   dir?: "->" | "<-"
 }
 
-export type CodeJar = ReturnType<typeof CodeJar>;
-
-export function CodeJar(editor: HTMLElement, highlight: (e: HTMLElement) => void, opt: Partial<Options> = {}) {
+export function CodeJarConstructor(editor: HTMLElement, highlight: (e: HTMLElement) => void, opt: Partial<Options> = {}) {
   const options = {
     tab: "\t",
     ...opt
@@ -442,3 +440,15 @@ export function CodeJar(editor: HTMLElement, highlight: (e: HTMLElement) => void
     },
   }
 }
+
+
+// Allows the use of `new CodeJar()` in TypeScript without raising the
+// "TS7009: 'new' expression, whose target lacks a construct signature, implicitly has an 'any' type"
+// warning.
+export declare interface CodeJarConstructor {
+  new(...args: Parameters<typeof CodeJarConstructor>): ReturnType<typeof CodeJarConstructor>;
+}
+// Allows the use of `CodeJar` as a type as well as a value, e.g.
+// `let jar: CodeJar = new CodeJar(...)`
+export type CodeJar = ReturnType<typeof CodeJarConstructor>;
+export const CodeJar: CodeJarConstructor = CodeJarConstructor as any;

--- a/codejar.ts
+++ b/codejar.ts
@@ -13,6 +13,8 @@ type Position = {
   dir?: "->" | "<-"
 }
 
+export type CodeJar = ReturnType<typeof CodeJar>;
+
 export function CodeJar(editor: HTMLElement, highlight: (e: HTMLElement) => void, opt: Partial<Options> = {}) {
   const options = {
     tab: "\t",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "author": "Anton Medvedev <anton@medv.io>",
   "homepage": "https://medv.io/codejar/",
   "main": "codejar.js",
+  "types": "codejar.d.ts",
   "files": [
     "*.ts",
     "*.js"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
       "dom"
     ],
     "strict": true,
+    "declaration": true,
     "noUnusedLocals": true
   }
 }


### PR DESCRIPTION
Implements the suggestions given in https://github.com/antonmedv/codejar/issues/13#issuecomment-626551908. 

* Export `CodeJar` type
* Updated the tsconfig to generate definitions file
* Set the package.json `types` property to point to main definition file
* Remove "new" keyword from docs