### PR TITLE
add line-numbers color option

### DIFF
--- a/linenumbers.ts
+++ b/linenumbers.ts
@@ -14,7 +14,7 @@ export function withLineNumbers(
     class: "codejar-linenumbers",
     wrapClass: "codejar-wrap",
     width: "35px",
-    backgroundColor: "rgba(255, 255, 255, 0.05)",
+    backgroundColor: "rgba(128, 128, 128, 0.15)",
     color: "",
     ...options
   }

--- a/linenumbers.ts
+++ b/linenumbers.ts
@@ -57,7 +57,7 @@ function init(editor: HTMLElement, opts: Options): HTMLElement {
   lineNumbers.style.bottom = "0px"
   lineNumbers.style.width = opts.width
   lineNumbers.style.overflow = "hidden"
-  lineNumbers.style.backgroundColor = opts.backgroundColor || "rgba(255, 255, 255, 0.05)"
+  lineNumbers.style.backgroundColor = opts.backgroundColor
   lineNumbers.style.color = opts.color || css.color
   lineNumbers.style.setProperty("mix-blend-mode", "difference")
 

--- a/linenumbers.ts
+++ b/linenumbers.ts
@@ -14,6 +14,8 @@ export function withLineNumbers(
     class: "codejar-linenumbers",
     wrapClass: "codejar-wrap",
     width: "35px",
+    backgroundColor: "rgba(255, 255, 255, 0.05)",
+    color: "",
     ...options
   }
 

--- a/linenumbers.ts
+++ b/linenumbers.ts
@@ -2,6 +2,8 @@ type Options = {
   class: string
   wrapClass: string
   width: string
+  backgroundColor: string
+  color: string
 }
 
 export function withLineNumbers(
@@ -53,8 +55,8 @@ function init(editor: HTMLElement, opts: Options): HTMLElement {
   lineNumbers.style.bottom = "0px"
   lineNumbers.style.width = opts.width
   lineNumbers.style.overflow = "hidden"
-  lineNumbers.style.backgroundColor = "rgba(255, 255, 255, 0.05)"
-  lineNumbers.style.color = "#fff"
+  lineNumbers.style.backgroundColor = opts.backgroundColor || "rgba(255, 255, 255, 0.05)"
+  lineNumbers.style.color = opts.color || css.color
   lineNumbers.style.setProperty("mix-blend-mode", "difference")
 
   // Copy editor styles


### PR DESCRIPTION
Thank you for a great little editor. I love it!

I notice that when the editor's background color is white, the line number text (and the background) colors are also set to white, making the line numbers "disappear."

This patch makes two changes to fix this issue:

(1) It changes the line number text color from "#fff" to css.color to inherit the text color of the editor
(2) It adds two options "backgroundColor" and "color" and makes it possible to custom set the line number colors