### PR TITLE
feat(codejar): customizable indent rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,16 @@ let jar = CodeJar(editor, highlight)
 ```
 
 Third argument to `CodeJar` is options:
+  - Options.tab replace "tabs" and "auto indent tabs" to given string
+    - Can use CSS tab-size instead
+    - If so, "auto indent tabs" can be removed with a single "backspace"
+  - Options.indentRegex allows indent rule to be customized
+    - Auto-tab if the last character match the given regex while pressing Enter
 
 ```js
 let options = {
   tab: ' '.repeat(4), // default is \t
+  indentRegex: /[([{'"]/ // default is /[{]/
 }
 
 let jar = CodeJar(editor, highlight, options)

--- a/codejar.ts
+++ b/codejar.ts
@@ -18,6 +18,7 @@ export type CodeJar = ReturnType<typeof CodeJar>
 export function CodeJar(editor: HTMLElement, highlight: (e: HTMLElement) => void, opt: Partial<Options> = {}) {
   const options = {
     tab: "\t",
+    indentRegex: /[{]/,
     ...opt
   }
   let listeners: [string, any][] = []
@@ -215,7 +216,8 @@ export function CodeJar(editor: HTMLElement, highlight: (e: HTMLElement) => void
       let newLinePadding = padding
 
       // If last symbol is "{" ident new line
-      if (before[before.length - 1] === "{") {
+      // Allow user defines indent rule
+      if (before[before.length - 1].match(indentRegex)) {
         newLinePadding += options.tab
       }
 


### PR DESCRIPTION
Depends on the variety of languages/code-styles, the indent rule should be customizable.
e.g. Markdown,  languages with indentation requirements...

I also added some info to README.
