### PR TITLE
Add `spellcheck` and `addClosing` options

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ Third argument to `CodeJar` is options:
     - Note: use css rule `tab-size` to customize size.
   - `identOn: RegExp` allows auto indent rule to be customized. Default `{$`
     - Auto-tab if the text before cursor match the given regex while pressing Enter.
-       
+  - `spellcheck: boolean` enables spellchecking on the editor. Default `false`
+
 
 ```js
 let options = {

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Third argument to `CodeJar` is options:
   - `identOn: RegExp` allows auto indent rule to be customized. Default `{$`
     - Auto-tab if the text before cursor match the given regex while pressing Enter.
   - `spellcheck: boolean` enables spellchecking on the editor. Default `false`
+  - `addClosing: boolean` automatically adds closing brackets, quotes. Default `true`
 
 
 ```js

--- a/codejar.ts
+++ b/codejar.ts
@@ -2,6 +2,7 @@ type Options = {
   tab: string
   indentOn: RegExp
   spellcheck: boolean
+  addClosing: boolean
 }
 
 type HistoryRecord = {
@@ -22,6 +23,7 @@ export function CodeJar(editor: HTMLElement, highlight: (e: HTMLElement) => void
     tab: "\t",
     indentOn: /{$/,
     spellcheck: false,
+    addClosing: true
     ...opt
   }
   let listeners: [string, any][] = []
@@ -74,7 +76,7 @@ export function CodeJar(editor: HTMLElement, highlight: (e: HTMLElement) => void
     prev = toString()
     handleNewLine(event)
     handleTabCharacters(event)
-    handleSelfClosingCharacters(event)
+    if (options.addClosing) handleSelfClosingCharacters(event)
     handleUndoRedo(event)
     if (shouldRecord(event) && !recording) {
       recordHistory()

--- a/codejar.ts
+++ b/codejar.ts
@@ -1,6 +1,7 @@
 type Options = {
   tab: string
   indentOn: RegExp
+  spellcheck: boolean
 }
 
 type HistoryRecord = {
@@ -20,6 +21,7 @@ export function CodeJar(editor: HTMLElement, highlight: (e: HTMLElement) => void
   const options: Options = {
     tab: "\t",
     indentOn: /{$/,
+    spellcheck: false,
     ...opt
   }
   let listeners: [string, any][] = []
@@ -31,7 +33,7 @@ export function CodeJar(editor: HTMLElement, highlight: (e: HTMLElement) => void
   let isFirefox = navigator.userAgent.toLowerCase().indexOf("firefox") > -1
 
   editor.setAttribute("contentEditable", isFirefox ? "true" : "plaintext-only")
-  editor.setAttribute("spellcheck", "false")
+  editor.setAttribute("spellcheck", options.spellcheck ? "true" : "false")
   editor.style.outline = "none"
   editor.style.overflowWrap = "break-word"
   editor.style.overflowY = "auto"


### PR DESCRIPTION
I would like to add the following options:
- `spellcheck: boolean` - enables spellchecking on the editor. When using the editor with code like markdown, it can be handy to have
- `addClosing: boolean` automatically adds closing brackets, quotes. Adds ability to disable automatically adding of brackets and quotes - some times can be erroneous and bovvering