### PR TITLE
Changed event.code to event.key

### DIFF
--- a/codejar.ts
+++ b/codejar.ts
@@ -366,11 +366,11 @@ export function CodeJar(editor: HTMLElement, highlight: (e: HTMLElement) => void
   }
 
   function isUndo(event: KeyboardEvent) {
-    return isCtrl(event) && !event.shiftKey && event.code === "KeyZ"
+    return isCtrl(event) && !event.shiftKey && event.key === "z"
   }
 
   function isRedo(event: KeyboardEvent) {
-    return isCtrl(event) && event.shiftKey && event.code === "KeyZ"
+    return isCtrl(event) && event.shiftKey && event.key === "z"
   }
 
   function insert(text: string) {


### PR DESCRIPTION
• With AZERTY keyboard for example, event.code contains « KeyW » on the Z key
• This fix ensure compatibility for CTRL+Z/CTRL+SHIFT+Z on all keyboards

Fix issue #29 