### PR TITLE
Optimized closing characters.

### DIFF
--- a/codejar.ts
+++ b/codejar.ts
@@ -249,13 +249,14 @@ export function CodeJar(editor: HTMLElement, highlight: (e: HTMLElement) => void
     const open = `([{'"`
     const close = `)]}'"`
     const codeAfter = afterCursor()
-    const codeBefore = beforeCursor();
-    if (close.includes(event.key) && codeBefore.substr(codeBefore.length-1) !== "\\" && codeAfter.substr(0, 1) === event.key) {
+    const codeBefore = beforeCursor()
+    var escapeCharacter = `'"`.includes(event.key) && codeBefore.substr(codeBefore.length-1) !== "\\"
+    if (close.includes(event.key) && escapeCharacter && codeAfter.substr(0, 1) === event.key) {
       const pos = save()
       preventDefault(event)
       pos.start = ++pos.end
       restore(pos)
-    } else if (open.includes(event.key) && codeBefore.substr(codeBefore.length-1) !== "\\") {
+    } else if (open.includes(event.key) && escapeCharacter) {
       const pos = save()
       preventDefault(event)
       const text = event.key + close[open.indexOf(event.key)]

--- a/codejar.ts
+++ b/codejar.ts
@@ -249,12 +249,13 @@ export function CodeJar(editor: HTMLElement, highlight: (e: HTMLElement) => void
     const open = `([{'"`
     const close = `)]}'"`
     const codeAfter = afterCursor()
-    if (close.includes(event.key) && codeAfter.substr(0, 1) === event.key) {
+    const codeBefore = beforeCursor();
+    if (close.includes(event.key) && codeBefore.substr(codeBefore.length-1) !== "\\" && codeAfter.substr(0, 1) === event.key) {
       const pos = save()
       preventDefault(event)
       pos.start = ++pos.end
       restore(pos)
-    } else if (open.includes(event.key)) {
+    } else if (open.includes(event.key) && codeBefore.substr(codeBefore.length-1) !== "\\") {
       const pos = save()
       preventDefault(event)
       const text = event.key + close[open.indexOf(event.key)]

--- a/codejar.ts
+++ b/codejar.ts
@@ -250,7 +250,7 @@ export function CodeJar(editor: HTMLElement, highlight: (e: HTMLElement) => void
     const close = `)]}'"`
     const codeAfter = afterCursor()
     const codeBefore = beforeCursor()
-    var escapeCharacter = `'"`.includes(event.key) && codeBefore.substr(codeBefore.length-1) !== "\\"
+    const escapeCharacter = `'"`.includes(event.key) && codeBefore.substr(codeBefore.length-1) !== "\\"
     if (close.includes(event.key) && escapeCharacter && codeAfter.substr(0, 1) === event.key) {
       const pos = save()
       preventDefault(event)


### PR DESCRIPTION
When typing a closing character for example the double quote (`"`), any closing characters inside this are also closed. This is good unless the characters are escaped by a backslash (`\`). When typing `"\"` you will get a doubly closed quote, such that the editor displays `"\"""`. This is an invalid string in most editors. Instead, the editor should display `"\""` which is a valid string. This request fixes this by testing for a backslash in the character before the cursor.