### PR TITLE
fix editing issues in Firefox

### DIFF
--- a/codejar.ts
+++ b/codejar.ts
@@ -50,7 +50,7 @@ export function CodeJar(editor: HTMLElement, highlight: (e: HTMLElement, pos?: P
   let isLegacy = false // true if plaintext-only is not supported
 
   highlight(editor)
-  if (editor.contentEditable !== "plaintext-only") isLegacy = true
+  if (editor.contentEditable !== 'plaintext-only') isLegacy = true
   if (isLegacy) editor.setAttribute('contenteditable', 'true')
 
   const debounceHighlight = debounce(() => {
@@ -129,13 +129,13 @@ export function CodeJar(editor: HTMLElement, highlight: (e: HTMLElement, pos?: P
     let {anchorNode, anchorOffset, focusNode, focusOffset} = s
     // selection anchor and focus are expected to be text nodes, so normalize them
     if (anchorNode.nodeType === Node.ELEMENT_NODE) {
-      const node = document.createTextNode("")
+      const node = document.createTextNode('')
       anchorNode.insertBefore(node, anchorNode.childNodes[anchorOffset])
       anchorNode = node
       anchorOffset = 0
     }
     if (focusNode.nodeType === Node.ELEMENT_NODE) {
-      const node = document.createTextNode("")
+      const node = document.createTextNode('')
       focusNode.insertBefore(node, focusNode.childNodes[focusOffset])
       focusNode = node
       focusOffset = 0

--- a/codejar.ts
+++ b/codejar.ts
@@ -95,7 +95,7 @@ export function CodeJar(editor: HTMLElement, highlight: (e: HTMLElement, pos?: P
       }
     }
     
-    restore(save())
+    if (isLegacy) restore(save())
   })
 
   on('keyup', event => {


### PR DESCRIPTION
By request, I’m moving the patch in https://github.com/antonmedv/codejar/issues/19#issuecomment-773108272 to a pull request.

This pull request aims to fix important usability features in Firefox and other Gecko browsers.

Changes include:

- Avoid explicitly checking specifically for Firefox, preferring to verify whether the browser supports `contenteditable="plaintext-only"`.
- Avoid mentioning Firefox in function and variable names.
- Normalize the selection before using it. Firefox will occasionally report elements (rather than text nodes) as selection endpoints, [per MDN docs][selection API].
- Work around an issue in Firefox when the selection is programmatically set to be at the very start (index `0`) of a text node containing only a line break. Firefox expects the selection to be at the end of the previous node in those cases, and will misbehave otherwise.
- Work around seemingly buggy selection behavior in Firefox when nodes are swapped around. It seems Firefox doesn’t like when nodes containing the selection are replaced entirely while the user is manipulating the selection, and it will reposition the selection in weird ways immediately before the `keyup` event is dispatched. Modifying the selection seems to suppress this behavior, so it suffices to write `restore(save())` during the `keydown` event dispatch.

[selection API]: https://developer.mozilla.org/en-US/docs/Web/API/Selection#properties