### PR TITLE
use KeyboardEvent code instead of key for multi language support

### DIFF
--- a/codejar.ts
+++ b/codejar.ts
@@ -412,11 +412,11 @@ export function CodeJar(editor: HTMLElement, highlight: (e: HTMLElement, pos?: P
   }
 
   function isUndo(event: KeyboardEvent) {
-    return isCtrl(event) && !event.shiftKey && event.key === 'z'
+    return isCtrl(event) && !event.shiftKey && event.code === 'KeyZ'
   }
 
   function isRedo(event: KeyboardEvent) {
-    return isCtrl(event) && event.shiftKey && event.key === 'z'
+    return isCtrl(event) && event.shiftKey && event.code === 'KeyZ'
   }
 
   function insert(text: string) {


### PR DESCRIPTION
Undo, Redo don't work, when using it with other language, ex. Russian. KeyboardEvent.key is equals to 'я' in such case.