### PR TITLE
Fix updateOptions

### DIFF
--- a/codejar.ts
+++ b/codejar.ts
@@ -464,8 +464,8 @@ export function CodeJar(editor: HTMLElement, highlight: (e: HTMLElement, pos?: P
   }
 
   return {
-    updateOptions(options: Partial<Options>) {
-      options = {...options, ...options}
+    updateOptions(newOptions: Partial<Options>) {
+      Object.assign(options, newOptions);
     },
     updateCode(code: string) {
       editor.textContent = code

--- a/codejar.ts
+++ b/codejar.ts
@@ -465,7 +465,7 @@ export function CodeJar(editor: HTMLElement, highlight: (e: HTMLElement, pos?: P
 
   return {
     updateOptions(newOptions: Partial<Options>) {
-      Object.assign(options, newOptions);
+      Object.assign(options, newOptions)
     },
     updateCode(code: string) {
       editor.textContent = code


### PR DESCRIPTION
Due to the argument name being the same as the outer `options` `const`, the following line did not correctly update the options hash.

```javascript
options = { ...options, ...options };
```

This PR resolves that issue by renaming the argument and using `Object.assign`.