### PR TITLE
Make Codejar compatible with SSR

### DIFF
--- a/codejar.ts
+++ b/codejar.ts
@@ -1,4 +1,7 @@
-const globalWindow = window
+import { getDocument, getWindow } from 'ssr-window';
+
+const window = getWindow();
+const document = getDocument();
 
 type Options = {
   tab: string
@@ -35,12 +38,9 @@ export function CodeJar(editor: HTMLElement, highlight: (e: HTMLElement, pos?: P
     preserveIdent: true,
     addClosing: true,
     history: true,
-    window: globalWindow,
+    window,
     ...opt
   }
-
-  const window = options.window
-  const document = window.document
 
   let listeners: [string, any][] = []
   let history: HistoryRecord[] = []

--- a/cursor.ts
+++ b/cursor.ts
@@ -1,3 +1,8 @@
+import { getDocument, getWindow } from 'ssr-window';
+
+const window = getWindow();
+const document = getDocument();
+
 type Position = {
   top: string
   left: string

--- a/package.json
+++ b/package.json
@@ -18,11 +18,14 @@
     "size": "minify codejar.js --sourceType module | gzip-size",
     "release": "release-it"
   },
+  "dependencies": {
+    "ssr-window": "^4.0.2"
+  },
   "devDependencies": {
+    "@types/node": "^18.8.4",
     "babel-minify": "^0.5.1",
     "gzip-size-cli": "^3.0.0",
     "release-it": "^14.5.1",
-    "ssr-window": "^4.0.2",
     "typescript": "^4.2.3"
   },
   "release-it": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "babel-minify": "^0.5.1",
     "gzip-size-cli": "^3.0.0",
     "release-it": "^14.5.1",
+    "ssr-window": "^4.0.2",
     "typescript": "^4.2.3"
   },
   "release-it": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,10 @@
     ],
     "strict": true,
     "declaration": true,
-    "noUnusedLocals": true
+    "noUnusedLocals": true,
+    "moduleResolution": "node",
+    "types": [
+      "node"
+    ]
   }
 }


### PR DESCRIPTION
Without mocking window and document this library does not work on nuxt or next like frameworks.