### PR TITLE
Added fix for Strg+C in Firefox

### DIFF
--- a/codejar.ts
+++ b/codejar.ts
@@ -457,7 +457,7 @@ export function CodeJar(editor: HTMLElement, highlight: (e: HTMLElement, pos?: P
     return isCtrl(event) && event.shiftKey && event.code === 'KeyZ'
   }
   
-  function isCopy(event) {
+  function isCopy(event: KeyboardEvent) {
       return isCtrl(event) && event.code === 'KeyC';
   }
 

--- a/codejar.ts
+++ b/codejar.ts
@@ -104,7 +104,7 @@ export function CodeJar(editor: HTMLElement, highlight: (e: HTMLElement, pos?: P
       }
     }
 
-    if (isLegacy) restore(save())
+    if (isLegacy && !isCopy(event)) restore(save())
   })
 
   on('keyup', event => {
@@ -455,6 +455,10 @@ export function CodeJar(editor: HTMLElement, highlight: (e: HTMLElement, pos?: P
 
   function isRedo(event: KeyboardEvent) {
     return isCtrl(event) && event.shiftKey && event.code === 'KeyZ'
+  }
+  
+  function isCopy(event) {
+      return isCtrl(event) && event.code === 'KeyC';
   }
 
   function insert(text: string) {


### PR DESCRIPTION
Strg+A then Strg+C sometimes lead to only copying a subselection in Firefox. This PR makes an exempt for that special case to make it work as intended.