### PR TITLE
Fix undo/redo not working on other keyboard layouts

### DIFF
--- a/codejar.ts
+++ b/codejar.ts
@@ -450,11 +450,19 @@ export function CodeJar(editor: HTMLElement, highlight: (e: HTMLElement, pos?: P
   }
 
   function isUndo(event: KeyboardEvent) {
-    return isCtrl(event) && !event.shiftKey && event.code === 'KeyZ'
+    return isCtrl(event) && !event.shiftKey && getKeyCode(event) === "Z"
   }
 
   function isRedo(event: KeyboardEvent) {
-    return isCtrl(event) && event.shiftKey && event.code === 'KeyZ'
+    return isCtrl(event) && event.shiftKey && getKeyCode(event) === "Z";
+  }
+
+  function getKeyCode(event: KeyboardEvent): string | undefined{
+    let key = (event.key || event.keyCode || event.which);
+    if (!key) {
+      return undefined;
+    }
+    return ((typeof key === "string") ? key : String.fromCharCode(key)).toUpperCase();
   }
 
   function insert(text: string) {


### PR DESCRIPTION
This PR fixes the non working undo/redo feature for other keyboard layouts e.g. QUERTZ. See #73 , #79 