### PR TITLE
callback when updateCode called

### DIFF
--- a/codejar.ts
+++ b/codejar.ts
@@ -539,6 +539,7 @@ export function CodeJar(editor: HTMLElement, highlight: (e: HTMLElement, pos?: P
     updateCode(code: string) {
       editor.textContent = code
       highlight(editor)
+      if (callback) callback(code)
     },
     onUpdate(cb: (code: string) => void) {
       callback = cb


### PR DESCRIPTION
Callback doesn't fire when update is used to set the content of the editor. This might be problematic for, say, keeping an editor that is both user and system-edited in sync with another dom element. This PR fixes this by running the callback whenever updateCode is called.