### PR TITLE
Add parameter to updateCode to optionaly prevent callback being called

### DIFF
--- a/codejar.ts
+++ b/codejar.ts
@@ -544,10 +544,10 @@ export function CodeJar(editor: HTMLElement, highlight: (e: HTMLElement, pos?: P
     updateOptions(newOptions: Partial<Options>) {
       Object.assign(options, newOptions)
     },
-    updateCode(code: string) {
+    updateCode(code: string, callOnUpdate: boolean = true) {
       editor.textContent = code
       doHighlight(editor)
-      onUpdate(code)
+      callOnUpdate && onUpdate(code)
     },
     onUpdate(callback: (code: string) => void) {
       onUpdate = callback


### PR DESCRIPTION
I wanted to sync changes between two editors by listening to updates and sending these to the remote editor and vice-versa. However this obviously creates an infinite loop as every call to updateCode also triggers onUpdate.

This optional parameter can be used to prevent such a loop.