### PR TITLE
Fix cursor jumping to bottom when editor is nested inside a shadow root

### DIFF
--- a/codejar.ts
+++ b/codejar.ts
@@ -534,10 +534,8 @@ export function CodeJar(editor: HTMLElement, highlight: (e: HTMLElement, pos?: P
   }
 
   function getSelection() {
-    if (editor.parentNode?.nodeType == Node.DOCUMENT_FRAGMENT_NODE) {
-      return (editor.parentNode as Document).getSelection()!
-    }
-    return window.getSelection()!
+    // @ts-ignore
+    return editor.getRootNode().getSelection() as Selection
   }
 
   return {


### PR DESCRIPTION
This is a more robust fix for when the editor is inside the shadow dom possibly nested with other nodes between it and the root.

Sorry for the @ts-ignore but TS doesn't know that document fragments have `getSelection()`

See #46, #47